### PR TITLE
Suppression des derniers `export defaults`

### DIFF
--- a/src/commands/anniversaire/[sub-commands]/list.cmd.ts
+++ b/src/commands/anniversaire/[sub-commands]/list.cmd.ts
@@ -1,6 +1,6 @@
 import { getBirthdays } from "$core/api/requests/member";
 import { memberPerPage } from "./list.const";
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { simpleEmbed } from "$core/utils/embed";
 import { dateFormat, getAge } from "$core/utils/function";
 import { CommandExecute } from "$core/utils/handler/command";

--- a/src/commands/anniversaire/[sub-commands]/next.cmd.ts
+++ b/src/commands/anniversaire/[sub-commands]/next.cmd.ts
@@ -3,7 +3,7 @@ import { simpleEmbed } from "$core/utils/embed";
 import { CommandExecute } from "$core/utils/handler/command";
 import { commands } from "$core/configs/message/command";
 import { gqlRequest } from "$core/utils/request";
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { msgParams } from "$core/utils/message";
 import { getAge } from "$core/utils/function";
 

--- a/src/commands/anniversaire/[sub-commands]/set.cmd.ts
+++ b/src/commands/anniversaire/[sub-commands]/set.cmd.ts
@@ -1,4 +1,4 @@
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { CommandExecute } from "$core/utils/handler/command";
 import { commands } from "$core/configs/message/command";
 import { global } from "$core/configs/global.config";

--- a/src/commands/member/member.cmd.ts
+++ b/src/commands/member/member.cmd.ts
@@ -2,7 +2,7 @@ import { getChannels } from "$core/api/requests/main-channel";
 import { getMember } from "$core/api/requests/member";
 import { getGuildTypeById, guilds } from "$core/configs/guild";
 import { commands } from "$core/configs/message/command";
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { simpleEmbed } from "$core/utils/embed";
 import { dateFormat, firstLetterToUppercase, formatMinutes, getAge, numberFormat } from "$core/utils/function";
 import { CommandExecute } from "$core/utils/handler/command";

--- a/src/commands/stats/stats.util.ts
+++ b/src/commands/stats/stats.util.ts
@@ -1,6 +1,6 @@
 import { GraphType } from "./stats.type";
 import { global } from "$core/configs";
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { dateFormat } from "$core/utils/function";
 import { GetServerActivityHistoryQuery } from "$core/utils/request/graphql/graphql";
 import { ChartConfiguration } from "chart.js";

--- a/src/tasks/birthday-checker/birthday-checker.task.ts
+++ b/src/tasks/birthday-checker/birthday-checker.task.ts
@@ -2,7 +2,7 @@ import { getBirthdays } from "$core/api/requests/member";
 import { client } from "$core/client";
 import { getGuild, guilds } from "$core/configs/guild";
 import { tasks } from "$core/configs/message/task/task.config";
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { simpleEmbed } from "$core/utils/embed";
 import { getAge } from "$core/utils/function";
 import { TaskExecute, TaskInterval } from "$core/utils/handler/task";

--- a/src/utils/day-js.ts
+++ b/src/utils/day-js.ts
@@ -7,6 +7,4 @@ dayjs.extend(timezone);
 
 dayjs.tz.setDefault("Europe/Paris");
 
-const DayJS = dayjs;
-
-export default DayJS;
+export const DayJS = dayjs;

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -1,6 +1,6 @@
 import { Dayjs } from "dayjs";
 import { global } from "$core/configs/global.config";
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 import { existsSync, statSync } from "fs";
 
 export const numberFormat = (number: number): string => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import DayJS from "$core/utils/day-js";
+import { DayJS } from "$core/utils/day-js";
 
 export enum ConsoleEffect {
   Reset = "\x1b[0m",


### PR DESCRIPTION
Close #198 

Pour le `export default` de `gql-codegen.ts`, je n'ai aucune idée de comment le supprimer. Je n'ai pas trouvé de solution sur https://the-guild.dev/graphql/codegen/docs/config-reference/documents-field