### PR TITLE
Correction d'un crash avec la function `gqlRequest()` lorsque l'API GraphQL renvoie une erreur qui n'est pas au format JSON 

### DIFF
--- a/src/utils/request/request.ts
+++ b/src/utils/request/request.ts
@@ -73,7 +73,8 @@ export const gqlRequest = async<D, V>(document: TypedDocumentNode<D, V>, variabl
 
   if (!response.ok) {
     logger.error("GraphQL request failed :");
-    console.log(await response.json());
+    console.log(JSON.stringify(document, null, 2));
+    console.log(await response.text());
 
     return {
       success: false


### PR DESCRIPTION
close #194 