### PR TITLE
Ajout d'un système pour créer un thread à chaque message

### DIFF
--- a/src/configs/env/env.dto.ts
+++ b/src/configs/env/env.dto.ts
@@ -4,5 +4,6 @@ export const envDTO = z.object({
   API_LINK: z.string().url(),
   API_TOKEN: z.string().uuid(),
   BOT_TOKEN: z.string().nonempty(),
-  GH_TOKEN: z.string().nonempty()
+  GH_TOKEN: z.string().nonempty(),
+  OPEN_AI: z.string().nonempty()
 });

--- a/src/events/message-create-thread/message-create-thread.event.ts
+++ b/src/events/message-create-thread/message-create-thread.event.ts
@@ -1,0 +1,34 @@
+import type { EventExecute, EventName } from "#/utils/handler/event";
+import type { ForumChannel, GuildTextBasedChannel, TextBasedChannel } from "discord.js";
+import { guilds } from "#/configs/guild";
+import { ChannelType } from "discord.js";
+import { chatWithAI } from "#/utils/openai/openai";
+
+export const event: EventName = "messageCreate";
+
+export const enableInDev = true;
+
+export const PROMPT_CREATE_THREAD = [
+  "Tu est un expert en génération de titre, tu génère un titre par rapport aux messages qu'on te donne, et tu répond SEULEMENT",
+  "avec le titre. Tu n'envoi pas de message, tu envoi juste le titre, tu ajoute aussi un émoji au début qui est en rapport",
+  "avec le contexte du message envoyé. Le titre ne doit pas  dépasser 100 caractères (1 caractère = 1 lettre, 1 chiffre",
+  ", 1 espace, 1 ponctuation, 1 symbole, 1 emoji)."
+].join(" ");
+
+export const execute: EventExecute<"messageCreate"> = async(message) => {
+  if (message.guild?.id !== guilds.pro.guildId) return;
+  if (message.author.bot) return;
+
+  const channel: GuildTextBasedChannel | TextBasedChannel | ForumChannel = message.channel;
+
+  if (channel.type === ChannelType.PublicThread && channel.parent) return;
+
+  if (channel.id !== "786216771723198514") return;
+
+  const title = await chatWithAI(message.content, PROMPT_CREATE_THREAD);
+
+  await message.startThread({
+    name: title,
+    reason: "Création automatique d'un thread"
+  }).then(thread => thread.leave());
+};

--- a/src/utils/openai/openai.ts
+++ b/src/utils/openai/openai.ts
@@ -1,0 +1,54 @@
+/* eslint-disable camelcase */
+import { restJsonRequest } from "../request";
+import { env } from "#/configs/env";
+
+export type ChatGPTResponse = {
+  id: string;
+  object: "chat_completion";
+  created: number;
+  model: "gpt-3.5-turbo";
+  choices: [{
+    index: number;
+    message: {
+      role: "assistant";
+      content: string;
+    };
+    finish_reason: "stop";
+  }];
+  usage: {
+    prompt_token: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export async function chatWithAI(message: string, systemContext?: string): Promise<string> {
+  const messages: {
+    role: "user" | "system" | "assistant";
+    content: string;
+  }[] = [];
+
+  if (systemContext) messages.push({ role: "system", content: systemContext });
+  messages.push({ role: "user", content: message });
+
+  const response = await restJsonRequest<ChatGPTResponse>(
+    "post", "https://api.openai.com/v1/chat/completions", {
+      headers: {
+        authorization: `Bearer ${env.OPEN_AI}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages,
+        temperature: 0.9,
+        max_tokens: 1000
+      })
+    }
+  );
+
+  if (!response.ok || !response.value.choices[0]) {
+    return "Excusez moi, je ne sais pas comment répondre à votre message.";
+  }
+
+  return response.value.choices[0].message.content;
+}


### PR DESCRIPTION
feat(message-create-thread.event.ts): add event handler for "messageCreate" event

- The event handler listens for the "messageCreate" event in the guild with the ID "guilds.pro.guildId".
- It ignores messages sent by bots.
- It checks if the message is sent in the channel with the ID "786216771723198514".
- It generates a title using the content of the message and a predefined prompt.
- It starts a thread with the generated title and leaves the thread.

feat(openai.ts): add chatWithAI function to interact with OpenAI API

- The chatWithAI function sends a message to the OpenAI API and receives a response.
- It constructs a request body with the message and system context (if provided).
- It sends a POST request to the OpenAI API with the request body.
- It handles the response and returns the generated content from the